### PR TITLE
Fixing import bug and adding addtl compatibility between bytes/strings

### DIFF
--- a/lib/py/src/protocol/TBinaryProtocol.py
+++ b/lib/py/src/protocol/TBinaryProtocol.py
@@ -118,10 +118,12 @@ class TBinaryProtocol(TProtocolBase):
     buff = pack("!d", dub)
     self.trans.write(buff)
 
-  def writeString(self, str):
-    encoded = bytearray(str, 'utf-8')
-    self.writeI32(len(encoded))
-    self.trans.write(encoded)
+  def writeString(self, buf):
+    # Write either bytes or str object
+    if isinstance(buf, str):
+        buf = bytearray(buf, 'utf-8')
+    self.writeI32(len(buf))
+    self.trans.write(buf)
 
   def readMessageBegin(self):
     sz = self.readI32()
@@ -219,9 +221,13 @@ class TBinaryProtocol(TProtocolBase):
     return val
 
   def readString(self):
-    len = self.readI32()
-    str = self.trans.readAll(len).decode('utf-8')
-    return str
+    len_data = self.readI32()
+    read_buf = self.trans.readAll(len_data)
+    try:
+        read_buf = read_buf.decode('utf-8')
+    except:
+        pass
+    return read_buf
 
 
 class TBinaryProtocolFactory:

--- a/lib/py/src/transport/TTransport.py
+++ b/lib/py/src/transport/TTransport.py
@@ -18,7 +18,6 @@
 #
 
 from io import BytesIO
-from cStringIO import StringIO as BytesIO
 from struct import pack, unpack
 from thrift.Thrift import TException
 


### PR DESCRIPTION
`cStringIO` is not a valid Python 3 module, so the redundant and erroneous import in TTransport.py has been removed. I've also added type checks to the `writeString()` and `readString()` functions in TBinaryProtocol.py so that they may be used in existing implementations that require `bytes` objects be read/written, not just unicode strings.
